### PR TITLE
input sanitizing to avoid infinite loop

### DIFF
--- a/millipede.c
+++ b/millipede.c
@@ -7,7 +7,7 @@ int main(int argc, char **argv) {
   char *padding_offsets[8] = {"  ", " ", "", " ", "  ", "   ", "    ", "   "};
 
   if (argc > 1) {
-    size = atoi(argv[1]);
+    size = abs(atoi(argv[1]));
   }
 
   printf("    ╚⊙ ⊙╝\n");


### PR DESCRIPTION
call with negative int as argument produced an infinite millipede.
